### PR TITLE
history changes

### DIFF
--- a/lib/Pod/Site/podsite.js
+++ b/lib/Pod/Site/podsite.js
@@ -80,14 +80,34 @@ $(document).ready(function() {
             return false;
         });
     };
-
+    
+    var base_uri = $('meta[name="base-uri"]').attr('content');
+    
+    var url_to_module = function (str) {
+        str = str.replace(location.origin, '');
+        str = str.replace(base_uri, '');
+        return str.replace(/[.]html$/, '').split('/').join('::');
+    };
+    
+    var load_module = function (url) {
+      $('#doc').load(url, function (text, status, xhr) {
+          if (xhr.status == 200) { return cb() }
+          $('#doc').html(
+              '<h4 class="oops">' + xhr.statusText + ': '
+              + url + '</h4'
+          );
+      });
+    }
+    
+    window.onpopstate = function (evt) {
+      if (evt.state && evt.state.url) {
+        load_module(evt.state.url);
+      }
+    }
+    
     var load = location.search.substring(1);
     if (!load) {
-        var loc = location.pathname;
-        $('meta[name="base-uri"]').each( function () {
-            loc = loc.replace(this.content, '');
-        });
-        load = loc.replace(/[.]html$/, '').split('/').join('::');
+        load = url_to_module(location.pathname);
         if (!load) load = 'toc';
     }
     var cl = $('<span class="cl">&#x25ba;</span>');
@@ -111,13 +131,10 @@ $(document).ready(function() {
                 $(node).children('a:first').addClass('sel');
                 $(node).children('a:first[name!=nodoc]').each( function () {
                     var url = this.href;
-                    $('#doc').load(url, function (text, status, xhr) {
-                        if (xhr.status == 200) { return cb() }
-                        $('#doc').html(
-                            '<h4 class="oops">' + xhr.statusText + ': '
-                            + url + '</h4'
-                        );
-                    });
+                    var module = url_to_module(url);
+                    if (module === 'toc') module = '';
+                    load_module(url);
+                    history.pushState({url:url}, null, base_uri+module);
                 });
                 tree.toggle_branch(node);
             },


### PR DESCRIPTION
These changes change the URL to the current module, so the URL could be copied and sent to colleagues.

Not all browsers support history stacks. I did not make any effort to test in browsers which do not support history stacks.

I tried to update the tree so that the current module would be selected, but this is difficult because changing the selection triggers the onselect method which would cause another history.pushState.
