### PR TITLE
Fix get_desc

### DIFF
--- a/lib/Pod/Site.pm
+++ b/lib/Pod/Site.pm
@@ -332,7 +332,7 @@ sub get_desc {
     # Cribbed from Module::Build::PodParser.
     while (<$fh>) {
         next unless /^=(?!cut)/ .. /^=cut/;  # in POD
-        last if ($desc) = /^  (?:  [a-z:]+  \s+ - \s+  )  (.*\S)  /ix;
+        last if ($desc) = /^  (?:  [a-z0-9:]+  \s+ - \s+  )  (.*\S)  /ix;
     }
 
     close $fh or die "Cannot close $file: $!\n";

--- a/lib/Pod/Site.pm
+++ b/lib/Pod/Site.pm
@@ -327,13 +327,15 @@ sub get_desc {
     my ($self, $what, $file) = @_;
 
     open my $fh, '<', $file or die "Cannot open $file: $!\n";
-    my $desc;
+    my ($desc, $encoding);
     local $_;
     # Cribbed from Module::Build::PodParser.
-    while (<$fh>) {
+    while (not ($desc and $encoding) and $_ = <$fh>) {
         next unless /^=(?!cut)/ .. /^=cut/;  # in POD
-        last if ($desc) = /^  (?:  [a-z0-9:]+  \s+ - \s+  )  (.*\S)  /ix;
+        ($desc) = /^  (?:  [a-z0-9:]+  \s+ - \s+  )  (.*\S)  /ix unless $desc;
+        ($encoding) = /^=encoding\s+(.*\S)/ unless $encoding;
     }
+    Encode::from_to($desc, $encoding, 'UTF-8') if $desc && $encoding;
 
     close $fh or die "Cannot close $file: $!\n";
     print "$what has no POD or no description in a =head1 NAME section\n"

--- a/t/get_desc.t
+++ b/t/get_desc.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use utf8;
+use Encode;
+use File::Temp qw/tempdir/;
+use Test::More;
+use Pod::Site;
+
+my $tmpdir = tempdir CLEANUP => 1;
+my $site = Pod::Site->new({
+    doc_root     => $tmpdir,
+    base_uri     => '/dummy/',
+    module_roots => $tmpdir,
+});
+
+is do {
+    $site->get_desc('MyClass1', \ Encode::encode_utf8(<<'.'));
+=head1 Name
+
+MyClass1 - The description of MyClass1
+
+=cut
+.
+}, Encode::encode_utf8('The description of MyClass1');
+
+done_testing;

--- a/t/get_desc.t
+++ b/t/get_desc.t
@@ -23,4 +23,16 @@ MyClass1 - The description of MyClass1
 .
 }, Encode::encode_utf8('The description of MyClass1');
 
+is do {
+    $site->get_desc('MyClass2', \ Encode::encode("iso-8859-1" => <<'.'));
+=encoding iso-8859-1
+
+=head1 Name
+
+MyClass2 - Thè déscrìptïön õf MyClass2
+
+=cut
+.
+}, Encode::encode_utf8('Thè déscrìptïön õf MyClass2');
+
 done_testing;


### PR DESCRIPTION
Hi. I found 2 issues of this module.
- 1). If the class's name contains any digits, get_desc() returns an empty string.
- 2). get_desc() doesn't take care of =encoding section.

My patch resolves these problems. Of course, each of my commits contains the suitable test.

If you don't like some of my commits, you might as well cherry-pick a commit that you like.
